### PR TITLE
Add timer, beep and vibration hooks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', '_bak'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,38 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocalStorage } from 'react-confection'
+import useTimer from './hooks/useTimer'
+import useBeep from './hooks/useBeep'
+import useVibrate from './hooks/useVibrate'
 
 import './App.css'
 
 
 function App() {
   const [bpm, setBpm] = useLocalStorage('bpm', 120)
-  
+  const [pattern, setPattern] = useLocalStorage('pattern', 4)
+  const [sound, setSound] = useLocalStorage('sound', true)
+  const [vibe, setVibe] = useLocalStorage('vibe', false)
+
   const [running, setRunning] = useState(false)
+
+  const beep = useBeep()
+  const vibrate = useVibrate()
+  const beatRef = useRef(0)
+  const { start, stop, setDuration } = useTimer(() => {
+    beatRef.current = (beatRef.current + 1) % pattern
+    const accent = beatRef.current === 0
+    if (sound) beep(accent)
+    if (vibe) vibrate(accent)
+  }, 60000 / bpm)
+
+  useEffect(() => {
+    setDuration(60000 / bpm)
+  }, [bpm, setDuration])
+
+  useEffect(() => {
+    if (running) start()
+    else stop()
+  }, [running, start, stop])
 
 
   return <>
@@ -22,6 +47,37 @@ function App() {
         max={300}
         step={1}
       />
+    </label>
+
+    <label>
+      Pattern:
+      <select
+        value={pattern}
+        onChange={(e) => setPattern(Number(e.target.value))}
+      >
+        <option value={2}>2/4</option>
+        <option value={3}>3/4</option>
+        <option value={4}>4/4</option>
+        <option value={6}>6/8</option>
+      </select>
+    </label>
+
+    <label>
+      <input
+        type="checkbox"
+        checked={sound}
+        onChange={(e) => setSound(e.target.checked)}
+      />
+      Sound
+    </label>
+
+    <label>
+      <input
+        type="checkbox"
+        checked={vibe}
+        onChange={(e) => setVibe(e.target.checked)}
+      />
+      Vibration
     </label>
 
     <button onClick={() => setRunning(!running)}>

--- a/src/hooks/useBeep.ts
+++ b/src/hooks/useBeep.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+/**
+ * Returns a function that plays a short beep. When `accent` is true a louder
+ * beep with a higher frequency is produced.
+ */
+export default function useBeep() {
+  const contextRef = useRef<AudioContext>()
+  const gainRef = useRef<GainNode>()
+
+  useEffect(() => {
+    const ctor =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext: typeof AudioContext })
+        .webkitAudioContext
+    const ctx = new ctor()
+    const gain = ctx.createGain()
+    gain.connect(ctx.destination)
+    contextRef.current = ctx
+    gainRef.current = gain
+    return () => {
+      ctx.close()
+    }
+  }, [])
+
+  return useCallback((accent = false) => {
+    const ctx = contextRef.current
+    const gain = gainRef.current
+    if (!ctx || !gain) return
+    const osc = ctx.createOscillator()
+    const g = ctx.createGain()
+    osc.type = 'sine'
+    osc.frequency.value = accent ? 880 : 440
+    g.gain.value = accent ? 1 : 0.5
+    osc.connect(g)
+    g.connect(gain)
+    osc.start()
+    g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.1)
+    osc.stop(ctx.currentTime + 0.1)
+  }, [])
+}

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Calls the provided callback every `duration` milliseconds while running.
+ * The timer can be started, stopped and the duration may be changed.
+ */
+export default function useTimer(
+  callback: (delta: number) => void,
+  initialDuration: number,
+) {
+  const [running, setRunning] = useState(false)
+  const [duration, setDuration] = useState(initialDuration)
+
+  const callbackRef = useRef(callback)
+  const frameRef = useRef<number>()
+  const prevRef = useRef<number>()
+
+  callbackRef.current = callback
+
+  const tick = useCallback(() => {
+    const now = Date.now()
+    const prev = prevRef.current ?? now
+    const delta = now - prev
+
+    if (delta >= duration) {
+      prevRef.current = now
+      callbackRef.current(delta)
+    }
+
+    frameRef.current = requestAnimationFrame(tick)
+  }, [duration])
+
+  useEffect(() => {
+    if (!running) return
+
+    prevRef.current = undefined
+    frameRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (frameRef.current) cancelAnimationFrame(frameRef.current)
+    }
+  }, [running, tick])
+
+  const start = useCallback(() => setRunning(true), [])
+  const stop = useCallback(() => setRunning(false), [])
+
+  return { running, start, stop, duration, setDuration }
+}

--- a/src/hooks/useVibrate.ts
+++ b/src/hooks/useVibrate.ts
@@ -1,0 +1,12 @@
+import { useCallback } from 'react'
+
+/**
+ * Returns a function that triggers a vibration pattern. When accent is true a
+ * longer vibration is used.
+ */
+export default function useVibrate() {
+  return useCallback((accent = false) => {
+    if (!('vibrate' in navigator)) return
+    navigator.vibrate(accent ? 50 : 20)
+  }, [])
+}


### PR DESCRIPTION
## Summary
- add sound timer & vibration hooks
- toggle sound, vibration and pattern from the main page
- ignore `_bak` folder for linting

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b0995181c83279e3fd61c2f857dbb